### PR TITLE
Stop using DOS line endings

### DIFF
--- a/giftwrap_plugins/builders/package_meta.py
+++ b/giftwrap_plugins/builders/package_meta.py
@@ -64,6 +64,7 @@ class PackageMetaBuilder(PackageBuilder):
         output = StringIO()
         writer = csv.DictWriter(output, delimiter=',',
                                 quoting=csv.QUOTE_MINIMAL,
+                                lineterminator="\n",
                                 fieldnames=ordered_fieldnames)
 
         for dep in dependencies:


### PR DESCRIPTION
Not sure why the default writer wants to use ^M, but that is ugly.
Fix it.
