### PR TITLE
Add launchpad licensing information

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 -e git+https://github.com/blueboxgroup/giftwrap.git#egg=giftwrap
+launchpadlib
+simplejson


### PR DESCRIPTION
Sometimes Launchpad has information about a python package. If the
package homepage happens to be Launchpad, check Launchpad for the
definitive licensing information.
